### PR TITLE
fix: WGPU Pipeline by type instead of per components

### DIFF
--- a/examples/mario/main.rs
+++ b/examples/mario/main.rs
@@ -3,7 +3,7 @@ mod collisions_system;
 
 use std::{path::Path, str::from_utf8};
 
-use legion::{IntoQuery, component};
+use legion::IntoQuery;
 use scion::{
     config::{scion_config::ScionConfigBuilder, window_config::WindowConfigBuilder},
     core::{

--- a/examples/taquin/main.rs
+++ b/examples/taquin/main.rs
@@ -13,7 +13,6 @@ use scion::{
     utils::file::app_base_path,
     Scion,
 };
-use winit::window::CursorIcon;
 
 #[derive(Debug)]
 struct Case(Coordinates);

--- a/examples/tetris/layer.rs
+++ b/examples/tetris/layer.rs
@@ -1,19 +1,18 @@
 use scion::{
     core::{
         components::{
-            maths::{camera::Camera, transform::Transform},
+            maths::transform::Transform,
             tiles::tileset::Tileset,
             ui::{font::Font, ui_image::UiImage, ui_text::UiText},
         },
         game_layer::SimpleGameLayer,
-        legion_ext::ScionResourcesExtension,
+        legion_ext::{ScionResourcesExtension, ScionWorldExtension},
         resources::time::TimerType,
     },
     legion::{Entity, Resources, World},
 };
 
 use crate::{asset_path, resources::TetrisResource};
-use scion::core::legion_ext::ScionWorldExtension;
 
 #[derive(Default)]
 pub struct TetrisLayer {

--- a/src/application.rs
+++ b/src/application.rs
@@ -34,7 +34,9 @@ use crate::{
         systems::{
             animations_system::animation_executer_system,
             asset_ref_resolver_system::{asset_ref_resolver_system, MaterialAssetResolverFn},
-            collider_systems::{colliders_cleaner_system, compute_collisions_system, debug_colliders_system},
+            collider_systems::{
+                colliders_cleaner_system, compute_collisions_system, debug_colliders_system,
+            },
             default_camera_system::default_camera_system,
             hide_propagation_system::{hide_propagated_deletion_system, hide_propagation_system},
             hierarchy_system::children_manager_system,
@@ -44,8 +46,8 @@ use crate::{
         },
     },
     rendering::{renderer_state::RendererState, RendererType},
+    utils::debug_ecs::try_debug,
 };
-use crate::utils::debug_ecs::try_debug;
 
 /// `Scion` is the entry point of any application made with Scion's lib.
 pub struct Scion {
@@ -98,7 +100,10 @@ impl Scion {
 
     fn initialize_internal_resources(&mut self) {
         let inner_size = self.window.as_ref().expect("No window found during setup").inner_size();
-        self.resources.insert(crate::core::resources::window::Window::new((inner_size.width, inner_size.height)));
+        self.resources.insert(crate::core::resources::window::Window::new((
+            inner_size.width,
+            inner_size.height,
+        )));
 
         let mut events = Events::default();
         events
@@ -261,7 +266,6 @@ impl ScionBuilder {
             .expect("An error occured while building the main game window");
 
         self.add_late_internal_systems_to_schedule();
-
 
         let renderer = self.renderer.into_boxed_renderer();
         let renderer_state = futures::executor::block_on(

--- a/src/core/components/maths/collider.rs
+++ b/src/core/components/maths/collider.rs
@@ -35,7 +35,7 @@ pub struct Collider {
     collider_type: ColliderType,
     collision_filter: Vec<ColliderMask>,
     collisions: Vec<Collision>,
-    debug_lines: bool
+    debug_lines: bool,
 }
 
 impl Collider {
@@ -46,10 +46,16 @@ impl Collider {
         collision_filter: Vec<ColliderMask>,
         collider_type: ColliderType,
     ) -> Self {
-        Collider { collider_mask, collider_type, collision_filter, collisions: vec![], debug_lines: false }
+        Collider {
+            collider_mask,
+            collider_type,
+            collision_filter,
+            collisions: vec![],
+            debug_lines: false,
+        }
     }
 
-    pub fn with_debug_lines(mut self) -> Self{
+    pub fn with_debug_lines(mut self) -> Self {
         self.debug_lines = true;
         self
     }
@@ -64,13 +70,9 @@ impl Collider {
     pub fn mask(&self) -> &ColliderMask { &self.collider_mask }
 
     /// Retrieve the collider type of this collider
-    pub fn collider_type(&self) -> &ColliderType {
-        &self.collider_type
-    }
+    pub fn collider_type(&self) -> &ColliderType { &self.collider_type }
 
-    pub(crate) fn debug_lines(&self) -> bool{
-        self.debug_lines
-    }
+    pub(crate) fn debug_lines(&self) -> bool { self.debug_lines }
 
     pub(crate) fn passive(&self) -> bool {
         self.collision_filter.len() == 1 && self.collision_filter.contains(&ColliderMask::None)
@@ -139,7 +141,7 @@ impl Collision {
 }
 
 /// Internal component used to keep track of a collider debug display
-pub (crate) struct ColliderDebug;
+pub(crate) struct ColliderDebug;
 
 #[cfg(test)]
 mod tests {

--- a/src/core/components/shapes/line.rs
+++ b/src/core/components/shapes/line.rs
@@ -45,7 +45,7 @@ impl Renderable2D for Line {
 
     fn range(&self) -> Range<u32> { 0..INDICES.len() as u32 }
 
-    fn topology(&self) -> PrimitiveTopology { wgpu::PrimitiveTopology::LineList }
+    fn topology() -> PrimitiveTopology { wgpu::PrimitiveTopology::LineList }
 
     fn dirty(&self) -> bool { false }
 

--- a/src/core/components/shapes/polygon.rs
+++ b/src/core/components/shapes/polygon.rs
@@ -72,9 +72,9 @@ impl Renderable2D for Polygon {
 
     fn range(&self) -> Range<u32> { 0..self.indices.len() as u32 }
 
-    fn topology(&self) -> PrimitiveTopology { wgpu::PrimitiveTopology::LineStrip }
+    fn topology() -> PrimitiveTopology { wgpu::PrimitiveTopology::LineStrip }
 
     fn dirty(&self) -> bool { self.dirty }
 
-    fn set_dirty(&mut self, is_dirty: bool) { self.dirty = is_dirty;}
+    fn set_dirty(&mut self, is_dirty: bool) { self.dirty = is_dirty; }
 }

--- a/src/core/components/shapes/rectangle.rs
+++ b/src/core/components/shapes/rectangle.rs
@@ -64,7 +64,7 @@ impl Renderable2D for Rectangle {
 
     fn range(&self) -> Range<u32> { 0..INDICES.len() as u32 }
 
-    fn topology(&self) -> PrimitiveTopology { wgpu::PrimitiveTopology::TriangleList }
+    fn topology() -> PrimitiveTopology { wgpu::PrimitiveTopology::TriangleList }
 
     fn dirty(&self) -> bool { false }
 

--- a/src/core/components/shapes/square.rs
+++ b/src/core/components/shapes/square.rs
@@ -81,7 +81,7 @@ impl Renderable2D for Square {
 
     fn range(&self) -> Range<u32> { 0..INDICES.len() as u32 }
 
-    fn topology(&self) -> PrimitiveTopology { wgpu::PrimitiveTopology::TriangleList }
+    fn topology() -> PrimitiveTopology { wgpu::PrimitiveTopology::TriangleList }
 
     fn dirty(&self) -> bool { false }
 

--- a/src/core/components/shapes/triangle.rs
+++ b/src/core/components/shapes/triangle.rs
@@ -49,7 +49,7 @@ impl Renderable2D for Triangle {
 
     fn range(&self) -> Range<u32> { 0..3 as u32 }
 
-    fn topology(&self) -> PrimitiveTopology { wgpu::PrimitiveTopology::TriangleList }
+    fn topology() -> PrimitiveTopology { wgpu::PrimitiveTopology::TriangleList }
 
     fn dirty(&self) -> bool { false }
 

--- a/src/core/components/tiles/sprite.rs
+++ b/src/core/components/tiles/sprite.rs
@@ -92,7 +92,7 @@ impl Renderable2D for Sprite {
 
     fn range(&self) -> Range<u32> { 0..INDICES.len() as u32 }
 
-    fn topology(&self) -> PrimitiveTopology { wgpu::PrimitiveTopology::TriangleList }
+    fn topology() -> PrimitiveTopology { wgpu::PrimitiveTopology::TriangleList }
 
     fn dirty(&self) -> bool { self.dirty }
 

--- a/src/core/components/tiles/tilemap.rs
+++ b/src/core/components/tiles/tilemap.rs
@@ -136,7 +136,7 @@ impl Renderable2D for Tilemap {
 
     fn range(&self) -> Range<u32> { todo!() }
 
-    fn topology(&self) -> PrimitiveTopology { wgpu::PrimitiveTopology::TriangleList }
+    fn topology() -> PrimitiveTopology { wgpu::PrimitiveTopology::TriangleList }
 
     fn dirty(&self) -> bool { todo!() }
 

--- a/src/core/components/ui/ui_image.rs
+++ b/src/core/components/ui/ui_image.rs
@@ -70,7 +70,7 @@ impl Renderable2D for UiImage {
 
     fn range(&self) -> Range<u32> { 0..INDICES.len() as u32 }
 
-    fn topology(&self) -> PrimitiveTopology { wgpu::PrimitiveTopology::TriangleList }
+    fn topology() -> PrimitiveTopology { wgpu::PrimitiveTopology::TriangleList }
 
     fn dirty(&self) -> bool { false }
 

--- a/src/core/components/ui/ui_text.rs
+++ b/src/core/components/ui/ui_text.rs
@@ -50,7 +50,7 @@ impl Renderable2D for UiTextImage {
 
     fn range(&self) -> Range<u32> { self.0.range() }
 
-    fn topology(&self) -> PrimitiveTopology { wgpu::PrimitiveTopology::TriangleList }
+    fn topology() -> PrimitiveTopology { wgpu::PrimitiveTopology::TriangleList }
 
     fn dirty(&self) -> bool { false }
 

--- a/src/core/event_handler.rs
+++ b/src/core/event_handler.rs
@@ -9,12 +9,10 @@ use crate::{
     config::scion_config::ScionConfig,
     core::{
         legion_ext::ScionResourcesExtension,
-        resources::{
-            inputs::{
-                keycode::KeyCode,
-                mouse::{MouseButton, MouseEvent},
-                InputState, KeyboardEvent,
-            },
+        resources::inputs::{
+            keycode::KeyCode,
+            mouse::{MouseButton, MouseEvent},
+            InputState, KeyboardEvent,
         },
     },
     rendering::renderer_state::RendererState,

--- a/src/core/legion_ext.rs
+++ b/src/core/legion_ext.rs
@@ -12,12 +12,12 @@ use crate::{
         resources::{
             asset_manager::AssetManager, events::Events,
             inputs::inputs_controller::InputsController, sound::AudioPlayer, time::Timers,
+            window::Window,
         },
         state::GameState,
     },
     legion::Entity,
 };
-use crate::core::resources::window::Window;
 
 pub(crate) struct PausableSystem<S> {
     pub(crate) system: S,
@@ -99,8 +99,7 @@ impl ScionResourcesExtension for Resources {
 
     /// retrieves the window from the resources
     fn window(&mut self) -> AtomicRefMut<Window> {
-        self.get_mut::<Window>()
-            .expect("The engine is missing the mandatory window resource")
+        self.get_mut::<Window>().expect("The engine is missing the mandatory window resource")
     }
 }
 

--- a/src/core/resources/window.rs
+++ b/src/core/resources/window.rs
@@ -7,7 +7,7 @@ use winit::window::CursorIcon;
 pub struct Window {
     width: u32,
     height: u32,
-    new_cursor: Option<CursorIcon>
+    new_cursor: Option<CursorIcon>,
 }
 
 impl Window {
@@ -20,13 +20,9 @@ impl Window {
         self.height = height;
     }
 
-    pub fn set_cursor(&mut self, icon: CursorIcon) {
-        self.new_cursor = Some(icon);
-    }
+    pub fn set_cursor(&mut self, icon: CursorIcon) { self.new_cursor = Some(icon); }
 
-    pub(crate) fn reset_new_cursor(&mut self) {
-        self.new_cursor = None
-    }
+    pub(crate) fn reset_new_cursor(&mut self) { self.new_cursor = None }
 
     pub fn dimensions(self) -> (u32, u32) { (self.width, self.height) }
 

--- a/src/rendering/mod.rs
+++ b/src/rendering/mod.rs
@@ -16,6 +16,8 @@ pub(crate) mod shaders;
 
 /// Trait to implement in order to create a renderer to use in a `Scion` application
 pub trait ScionRenderer {
+    fn start(&mut self, device: &Device, surface_config: &SurfaceConfiguration);
+
     /// Will be called first, before render, each time the window request redraw.
     fn update(
         &mut self,
@@ -61,7 +63,7 @@ pub(crate) trait Renderable2D {
     fn vertex_buffer_descriptor(&mut self, material: Option<&Material>) -> BufferInitDescriptor;
     fn indexes_buffer_descriptor(&self) -> BufferInitDescriptor;
     fn range(&self) -> Range<u32>;
-    fn topology(&self) -> wgpu::PrimitiveTopology;
+    fn topology() -> wgpu::PrimitiveTopology;
     fn dirty(&self) -> bool;
     fn set_dirty(&mut self, is_dirty: bool);
 }

--- a/src/rendering/renderer_state.rs
+++ b/src/rendering/renderer_state.rs
@@ -13,7 +13,7 @@ pub(crate) struct RendererState {
 }
 
 impl RendererState {
-    pub(crate) async fn new(window: &Window, scion_renderer: Box<dyn ScionRenderer>) -> Self {
+    pub(crate) async fn new(window: &Window, mut scion_renderer: Box<dyn ScionRenderer>) -> Self {
         let size = window.inner_size();
         let instance = wgpu::Instance::new(wgpu::Backends::PRIMARY);
         let surface = unsafe { instance.create_surface(window) };
@@ -36,6 +36,7 @@ impl RendererState {
             )
             .await
             .unwrap();
+
         let swapchain_format = surface.get_preferred_format(&adapter).unwrap();
         let config = SurfaceConfiguration {
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
@@ -45,6 +46,8 @@ impl RendererState {
             present_mode: wgpu::PresentMode::Immediate,
         };
         surface.configure(&device, &config);
+
+        scion_renderer.start(&device, &config);
 
         Self { surface, device, queue, config, scion_renderer }
     }

--- a/src/utils/debug_ecs.rs
+++ b/src/utils/debug_ecs.rs
@@ -1,15 +1,14 @@
-use legion::{World, Resources, Entity, IntoQuery};
-use crate::core::legion_ext::ScionResourcesExtension;
-use crate::core::resources::inputs::keycode::KeyCode;
+use legion::{Entity, IntoQuery, Resources, World};
+
+use crate::core::{legion_ext::ScionResourcesExtension, resources::inputs::keycode::KeyCode};
 
 pub fn try_debug(world: &mut World, resources: &mut Resources) {
     resources.inputs().keyboard().on_key_pressed(KeyCode::P, || {
-        let mut query = <(Entity)>::query();
+        let mut query = <Entity>::query();
         let v: Vec<Entity> = query.iter(world).map(|e| *e).collect();
         v.iter().for_each(|e| {
             let entry = world.entry(*e).unwrap();
             println!("{:?}: {:?}", e, entry.archetype());
-        }
-        );
+        });
     });
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,5 +1,5 @@
 //! Utilities provided by `Scion` to help to do some basic stuff.
+pub(crate) mod debug_ecs;
 pub mod file;
 pub mod logger;
 pub mod maths;
-pub(crate) mod debug_ecs;


### PR DESCRIPTION
FIXES #177 

I was generating one pipeline per components instance, and renewing the pipeline when component was dirty. 
Now, pipeline is in memory per component Type and shared between instances.