### PR TITLE
fix(tetris): move 2 lines down

### DIFF
--- a/examples/tetris/systems/score_system.rs
+++ b/examples/tetris/systems/score_system.rs
@@ -59,12 +59,11 @@ pub fn score(
                 _ => {}
             };
         }
-        for (index, line) in lines2.iter().enumerate() {
+        for line in lines2.iter() {
             for (_, bloc, transform) in query.iter_mut(world) {
                 match bloc.kind {
                     BlocKind::Static => {
-                        if (*line - index as usize)
-                            > (transform.translation().y() / BLOC_SIZE) as usize
+                        if *line > (transform.translation().y() / BLOC_SIZE) as usize
                         {
                             transform.move_down(BLOC_SIZE);
                         }

--- a/examples/tetris/systems/score_system.rs
+++ b/examples/tetris/systems/score_system.rs
@@ -24,47 +24,47 @@ pub fn score(
     for (_, bloc, transform) in query.iter_mut(world) {
         match bloc.kind {
             BlocKind::Static => {
-                let key = (transform.translation().y() / BLOC_SIZE) as usize;
-                let new_val = match lines.get(&key) {
+                let line_idx = (transform.translation().y() / BLOC_SIZE) as usize;
+                let bloc_counter = match lines.get(&line_idx) {
                     Some(val) => val + 1,
                     None => 1,
                 };
-                lines.insert(key, new_val);
+                lines.insert(line_idx, bloc_counter);
             }
             _ => {}
         }
     }
 
-    let lines2 = {
+    let full_lines = {
         let mut full_lines = Vec::new();
-        for (key, val) in lines.iter() {
-            if val == &10 {
+        for (line_idx, bloc_counter) in lines.iter() {
+            if bloc_counter == &10 {
                 tetris.score += 1;
-                full_lines.push(*key);
+                full_lines.push(*line_idx);
             }
         }
         full_lines.sort_unstable();
         full_lines
     };
 
-    if !lines2.is_empty() {
+    if !full_lines.is_empty() {
         for (entity, bloc, transform) in query.iter_mut(world) {
             match bloc.kind {
                 BlocKind::Static => {
-                    let line = (transform.translation().y() / BLOC_SIZE) as usize;
-                    if lines2.contains(&line) {
+                    let line_idx = (transform.translation().y() / BLOC_SIZE) as usize;
+                    if full_lines.contains(&line_idx) {
                         cmd.remove(*entity);
                     }
                 }
                 _ => {}
             };
         }
-        for line in lines2.iter() {
+        for full_line_idx in full_lines.iter() {
             for (_, bloc, transform) in query.iter_mut(world) {
                 match bloc.kind {
                     BlocKind::Static => {
-                        if *line > (transform.translation().y() / BLOC_SIZE) as usize
-                        {
+                        let line_idx = (transform.translation().y() / BLOC_SIZE) as usize;
+                        if *full_line_idx > line_idx {
                             transform.move_down(BLOC_SIZE);
                         }
                     }


### PR DESCRIPTION
I don't understand why do you remove index to line : if a block is on a line upper than removed line, it should move down. This is independent of removed line index in 'lines2' array.

I have tested with 2 and 3 lines removed and it work.

If you are ok with that, I can also refactor this code to rename variables like `lines2`.