### PR TITLE
feat(transform): Allow a transform to use screen as origin

### DIFF
--- a/examples/mario/main.rs
+++ b/examples/mario/main.rs
@@ -25,6 +25,7 @@ use scion::{
     utils::file::{app_base_path, read_file},
     Scion,
 };
+use scion::core::components::maths::transform::TransformBuilder;
 
 use crate::{character_control_system::move_char_system, collisions_system::collider_system};
 

--- a/src/core/components/maths/transform.rs
+++ b/src/core/components/maths/transform.rs
@@ -19,6 +19,7 @@ pub struct Transform {
     pub(crate) angle: f32,
     pub(crate) dirty: bool,
     pub(crate) dirty_child: bool,
+    pub(crate) use_screen_as_origin: bool,
     bounds: Bounds,
 }
 
@@ -31,6 +32,7 @@ impl Default for Transform {
             angle: 0.0,
             dirty: false,
             dirty_child: true,
+            use_screen_as_origin: false,
             bounds: Default::default(),
         }
     }
@@ -46,6 +48,7 @@ impl Transform {
             angle,
             dirty: false,
             dirty_child: true,
+            use_screen_as_origin: false,
             bounds: Default::default(),
         }
     }
@@ -134,6 +137,11 @@ impl Transform {
         self.handle_bounds();
     }
 
+    pub fn set_use_screen_as_origin(&mut self, new_value: bool) {
+        self.use_screen_as_origin = new_value;
+        self.handle_bounds();
+    }
+
     /// Configure the minimum and maximum global values of x and y
     pub fn set_global_translation_bounds(
         &mut self,
@@ -214,6 +222,11 @@ impl TransformBuilder {
 
     pub fn with_angle(mut self, angle: f32) -> Self {
         self.transform.angle = angle;
+        self
+    }
+
+    pub fn with_screen_as_origin(mut self) -> Self{
+        self.transform.use_screen_as_origin = true;
         self
     }
 

--- a/src/rendering/gl_representations.rs
+++ b/src/rendering/gl_representations.rs
@@ -160,7 +160,7 @@ impl From<UniformData<'_>> for GlUniform {
             y: uniform_data.transform.global_translation.y(),
             z: uniform_data.transform.global_translation.z() as f32,
         });
-        if !uniform_data.is_ui_component {
+        if !uniform_data.is_ui_component && !uniform_data.transform.use_screen_as_origin {
             model_trans.append_translation(Vec3 {
                 x: -1. * uniform_data.camera.1.global_translation().x(),
                 y: -1. * uniform_data.camera.1.global_translation().y(),


### PR DESCRIPTION
Made this so a transform can be 'locked' to use top left screen as origin.

This maybe bring the subject : Do we need to keep UIComponent structs ? Let's deep dive on this in 0.7